### PR TITLE
Minor Typos

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -106,11 +106,11 @@ const config: Config = {
           title: 'Guides',
           items: [
             {
-              label: 'React comoonents',
+              label: 'React components',
               to: '/docs/guides/react',
             },
             {
-              label: 'Web comoonents',
+              label: 'Web components',
               to: '/docs/guides/web-components',
             },
             {


### PR DESCRIPTION
Spelling mistake. 
![Screenshot 2024-12-02 at 7 48 50 PM](https://github.com/user-attachments/assets/a2829d89-8a57-4c35-ada4-216e691d05da)
