### PR TITLE
fix: preserve slide styles in tile effect transitions

### DIFF
--- a/.changeset/tile-effect-styles-fix.md
+++ b/.changeset/tile-effect-styles-fix.md
@@ -1,0 +1,5 @@
+---
+'@boxslider/slider': minor
+---
+
+Fix tile effect transitions preserving slide styles. Previously, tile effects were removing all styles from slide elements when cloning them for transitions. Now only the visibility property is removed, preserving any custom styling applied to slides.

--- a/packages/slider/src/effects/tile/fade-transition.ts
+++ b/packages/slider/src/effects/tile/fade-transition.ts
@@ -63,7 +63,7 @@ class FadeTransition implements TileTransition {
 
   setTileFace(slide: HTMLElement, tileFace: HTMLElement) {
     const clone = slide.cloneNode(true) as HTMLElement
-    clone.removeAttribute('style')
+    clone.style.removeProperty('visibility')
     tileFace.replaceChildren(clone)
   }
 }

--- a/packages/slider/src/effects/tile/flip-transition.ts
+++ b/packages/slider/src/effects/tile/flip-transition.ts
@@ -88,7 +88,7 @@ class FlipTransition implements TileTransition {
 
   setTileFace(slide: HTMLElement, tileFace: HTMLElement) {
     const clone = slide.cloneNode(true) as HTMLElement
-    clone.removeAttribute('style')
+    clone.style.removeProperty('visibility')
     tileFace.firstElementChild!.replaceChildren(clone)
   }
 }


### PR DESCRIPTION
## Summary
- Fix tile effect transitions removing all slide styles
- Change from `removeAttribute('style')` to `style.removeProperty('visibility')`
- Preserves custom styling while still removing visibility property
- Includes minor changeset for @boxslider/slider package

## Test plan
- [x] Verify tile fade transition preserves slide styles
- [x] Verify tile flip transition preserves slide styles  
- [x] Confirm visibility property is still properly removed
- [x] Test with custom styled slides

🤖 Generated with [Claude Code](https://claude.ai/code)